### PR TITLE
Use Ratios.jl for faster rationals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
+Ratios = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [weakdeps]
@@ -13,13 +14,14 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 DynamicUnitsUnitfulExt = "Unitful"
 
 [compat]
+Ratios = "0.4"
 Requires = "1"
 Unitful = "1"
 julia = "1.6"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]

--- a/src/DynamicUnits.jl
+++ b/src/DynamicUnits.jl
@@ -3,6 +3,8 @@ module DynamicUnits
 export Quantity, Dimensions, ustrip, dimension, valid
 export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
 
+import Ratios: SimpleRatio
+
 include("types.jl")
 include("utils.jl")
 include("math.jl")

--- a/src/math.jl
+++ b/src/math.jl
@@ -23,7 +23,7 @@ Base.:^(l::Quantity, r::Quantity) =
     let rr = tryrationalize(Int, r.value)
         Quantity(l.value^rr, l.dimensions^rr, l.valid && r.valid && iszero(r.dimensions))
     end
-Base.:^(l::Dimensions, r::Rational{Int}) = @map_dimensions(Base.Fix1(*, r), l)
+Base.:^(l::Dimensions, r::R) = @map_dimensions(Base.Fix1(*, r), l)
 Base.:^(l::Dimensions, r::Number) = l^tryrationalize(Int, r)
 Base.:^(l::Quantity, r::Number) =
     let rr = tryrationalize(Int, r)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,6 @@
-const R = Rational{Int}
+import Ratios: SimpleRatio
+
+const R = SimpleRatio{Int}
 const DIMENSION_NAMES = (:length, :mass, :time, :current, :temperature, :luminosity, :amount)
 const DIMENSION_SYNONYMS = (:𝐋, :𝐌, :𝐓, :𝐈, :𝚯, :𝐉, :𝐍)
 const SYNONYM_MAPPING = NamedTuple(DIMENSION_NAMES .=> DIMENSION_SYNONYMS)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,12 +76,9 @@ to_superscript(s::AbstractString) = join(
     end
 )
 
-tryrationalize(::Type{<:Integer}, x::R) = x
 tryrationalize(::Type{<:Integer}, x::Rational) = R(x)
 tryrationalize(::Type{<:Integer}, x::Integer) = R(x)
 tryrationalize(::Type{<:Integer}, x) = simple_ratio_rationalize(x)
-simple_ratio_rationalize(x::R) = x
-simple_ratio_rationalize(x::Rational{Int}) = R(x)
 simple_ratio_rationalize(x) = isinteger(x) ? R(round(Int, x)) : R(rationalize(Int, x))
 
 ustrip(q::Quantity) = q.value

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -62,10 +62,11 @@ Base.show(io::IO, d::Dimensions) =
     end
 Base.show(io::IO, q::Quantity) = q.valid ? print(io, q.value, " ", q.dimensions) : print(io, "INVALID")
 
-tryround(x::Rational{Int}) = isinteger(x) ? round(Int, x) : x
-pretty_print_exponent(io::IO, x::Rational{Int}) =
+string_rational(x::Rational) = isinteger(x) ? string(x.num) : string(x)
+string_rational(x::SimpleRatio) = string_rational(x.num // x.den)
+pretty_print_exponent(io::IO, x::R) =
     let
-        print(io, " ", to_superscript(string(tryround(x))))
+        print(io, " ", to_superscript(string_rational(x)))
     end
 const SUPERSCRIPT_MAPPING = ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹']
 const INTCHARS = ['0' + i for i = 0:9]
@@ -75,9 +76,13 @@ to_superscript(s::AbstractString) = join(
     end
 )
 
-tryrationalize(::Type{T}, x::Rational{T}) where {T<:Integer} = x
-tryrationalize(::Type{T}, x::T) where {T<:Integer} = Rational{T}(x)
-tryrationalize(::Type{T}, x) where {T<:Integer} = rationalize(T, x)
+tryrationalize(::Type{<:Integer}, x::R) = x
+tryrationalize(::Type{<:Integer}, x::Rational) = R(x)
+tryrationalize(::Type{<:Integer}, x::Integer) = R(x)
+tryrationalize(::Type{<:Integer}, x) = simple_ratio_rationalize(x)
+simple_ratio_rationalize(x::R) = x
+simple_ratio_rationalize(x::Rational{Int}) = R(x)
+simple_ratio_rationalize(x) = isinteger(x) ? R(round(Int, x)) : R(rationalize(Int, x))
 
 ustrip(q::Quantity) = q.value
 ustrip(q::Number) = q

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -5,25 +5,25 @@ using Test
 
     x = Quantity(0.2, length=1, mass=2.5)
 
-    @test ulength(x) === 1 // 1
-    @test umass(x) === 5 // 2
+    @test ulength(x) == 1 // 1
+    @test umass(x) == 5 // 2
     @test valid(x)
-    @test ustrip(x) === 0.2
+    @test ustrip(x) == 0.2
     @test dimension(x) == Dimensions(length=1, mass=5 // 2)
     @test typeof(x).parameters[1] == Float64
 
     y = x^2
 
-    @test ulength(y) === 2 // 1
-    @test umass(y) === 5 // 1
+    @test ulength(y) == 2 // 1
+    @test umass(y) == 5 // 1
     @test ustrip(y) ≈ 0.04
     @test valid(y)
     @test typeof(y).parameters[1] == Float64
 
     y = x + x
 
-    @test ulength(y) === 1 // 1
-    @test umass(y) === 5 // 2
+    @test ulength(y) == 1 // 1
+    @test umass(y) == 5 // 2
     @test ustrip(y) ≈ 0.4
     @test valid(y)
 
@@ -36,21 +36,21 @@ using Test
 
     y = inv(x)
 
-    @test ulength(y) === -1 // 1
-    @test umass(y) === -5 // 2
+    @test ulength(y) == -1 // 1
+    @test umass(y) == -5 // 2
     @test ustrip(y) ≈ 5
     @test valid(y)
 
     y = x - x
 
-    @test iszero(x) === false
-    @test iszero(y) === true
-    @test iszero(y.dimensions) === false
+    @test iszero(x) == false
+    @test iszero(y) == true
+    @test iszero(y.dimensions) == false
 
     y = x / x
 
-    @test iszero(x.dimensions) === false
-    @test iszero(y.dimensions) === true
+    @test iszero(x.dimensions) == false
+    @test iszero(y.dimensions) == true
 
     y = Quantity(2 // 10, length=1, mass=5 // 2)
 
@@ -71,7 +71,7 @@ using Test
 
     y = x^2.1
 
-    @test ulength(y) === 1 * (21 // 10)
+    @test ulength(y) == 1 * (21 // 10)
     @test umass(y) == (5 // 2) * (21 // 10)
     @test utime(y) == 0
     @test ucurrent(y) == 0
@@ -79,7 +79,7 @@ using Test
     @test uluminosity(y) == 0
     @test uamount(y) == 0
     @test ustrip(y) ≈ 0.2^2.1
-    @test ustrip(y) === 0.2^(21 // 10)
+    @test ustrip(y) == 0.2^(21 // 10)
 
     x1 = Quantity(0.5)
     x2 = Quantity(10.0, length=1)


### PR DESCRIPTION
Turns out the built-in `Rational{Int}` in Julia is fairly slow because it computes `gcd` constantly. This switches to @timholy's `Ratios.SimpleRatio{Int}` instead, which is faster, but at a slightly higher risk of overflow.